### PR TITLE
fix spiralPrint function skipping some elements is fixed - #10

### DIFF
--- a/Chapter5(Arrays).js
+++ b/Chapter5(Arrays).js
@@ -321,27 +321,27 @@ function spiralPrint(M) {
         btmRow = M.length - 1,
         rightCol = M[0].length - 1;
 
-    while (topRow < btmRow && leftCol < rightCol) {
-        for (var col = 0; col <= rightCol; col++) {
+    while (topRow <= btmRow && leftCol <= rightCol) {
+        for (var col = leftCol; col <= rightCol; col++) {
             console.log(M[topRow][col]);
         }
         topRow++;
+
         for (var row = topRow; row <= btmRow; row++) {
             console.log(M[row][rightCol]);
         }
         rightCol--;
-        if (topRow <= btmRow) {
-            for (var col = rightCol; col > 0; col--) {
-                console.log(M[btmRow][col]);
-            }
-            btmRow--;
+
+        for (var col = rightCol; col >= leftCol; col--) {
+            console.log(M[btmRow][col]);
         }
-        if (leftCol <= rightCol) {
-            for (var row = btmRow; row > topRow; row--) {
-                console.log(M[row][leftCol]);
-            }
-            leftCol++;
+        btmRow--;
+
+
+        for (var row = btmRow; row >= topRow; row--) {
+            console.log(M[row][leftCol]);
         }
+        leftCol++;
     }
 }
 spiralPrint(M);


### PR DESCRIPTION
In the original algorithm with the following input

var M = [ [1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [16, 17, 18, 19, 20]];

it returns "1 2 3 4 5 10 15 20 19 18 17 11 6 7 8 9 14 13 12 " which skips 16.

Please check if the newly written code works fine. Thanks!